### PR TITLE
In class CASClientV1, the service url is in self.service_url and not in self.service

### DIFF
--- a/cas.py
+++ b/cas.py
@@ -111,7 +111,7 @@ class CASClientV1(CASClientBase):
 
         Returns username on success and None on failure.
         """
-        params = [('ticket', ticket), ('service', self.service)]
+        params = [('ticket', ticket), ('service', self.service_url)]
         url = (urllib_parse.urljoin(self.server_url, 'validate') + '?' +
                urllib_parse.urlencode(params))
         page = urllib_request.urlopen(url)


### PR DESCRIPTION
Otherwise, verify_ticket crash with the following exception:

```
AttributeError: 'CASClientV1' object has no attribute 'service'
```
