### PR TITLE
In SAMLV1.1, the user username is withing NameIdentifier tags

### DIFF
--- a/cas.py
+++ b/cas.py
@@ -271,6 +271,9 @@ class CASClientWithSAMLV1(CASClientV2, SingleLogoutMixin):
             success = tree.find('.//' + SAML_1_0_PROTOCOL_NS + 'StatusCode')
             if success is not None and success.attrib['Value'].endswith(':Success'):
                 # User is validated
+                name_identifier = tree.find('.//' + SAML_1_0_ASSERTION_NS + 'NameIdentifier')
+                if name_identifier is not None:
+                    user = name_identifier.text
                 attrs = tree.findall('.//' + SAML_1_0_ASSERTION_NS + 'Attribute')
                 for at in attrs:
                     if self.username_attribute in list(at.attrib.values()):


### PR DESCRIPTION
<NameIdentifier> tag is well present in the XML returned by the mainline
jasig CAS implementation. See https://wiki.jasig.org/display/CASUM/SAML+1.1
for an example.

Here, if self.username_attribute is defined, it will prevail upon the value in <NameIdentifier>.
If <NameIdentifier> is not present, the behaviour remain unchanged.
