### PR TITLE
Improve CASv2 XML parsing when response is not standard

### DIFF
--- a/cas.py
+++ b/cas.py
@@ -193,10 +193,11 @@ class CASClientV2(CASClientBase):
 
         tree = ElementTree.fromstring(response)
         if tree[0].tag.endswith('authenticationSuccess'):
+            """ Get namespace for looking for elements by tagname """
+            namespace = tree.tag[0:tree.tag.index('}')+1]
+            user = tree[0].find('.//' + namespace + 'user').text
             for element in tree[0]:
-                if element.tag.endswith('user'):
-                    user = element.text
-                elif element.tag.endswith('proxyGrantingTicket'):
+                if element.tag.endswith('proxyGrantingTicket'):
                     pgtiou = element.text
                 elif element.tag.endswith('attributes'):
                     attributes = cls.parse_attributes_xml_element(element)

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -193,3 +193,10 @@ def test_cas2_jasig_attributes(client_v2):
         'nombroj': ['unu', 'du', 'tri', 'kvar'],
     }
     assert attributes == expected_attributes
+
+SUCCESS_RESPONSE_WITH_NON_STANDARD_USER_NODE = """<?xml version="1.0" encoding="UTF-8"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"><cas:authenticationSuccess><cas:utilisateur><cas:displayName>John Doe</cas:displayName><cas:user>someuser</cas:user><cas:uid>someuser</cas:uid></cas:utilisateur></cas:authenticationSuccess></cas:serviceResponse>
+"""
+def test_cas2_non_standard_user_node(client_v2):
+    user, attributes, pgtiou = client_v2.verify_response(SUCCESS_RESPONSE_WITH_NON_STANDARD_USER_NODE)
+    assert user == 'someuser'


### PR DESCRIPTION
Ok, so I was quietly configuring a CAS connection for one of our client when suddenly this XML response was returned to me:

`<?xml version="1.0" encoding="UTF-8"?>
<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas"><cas:authenticationSuccess><cas:utilisateur><cas:displayName>John Doe</cas:displayName><cas:user>someuser</cas:user><cas:uid>someuser</cas:uid></cas:utilisateur></cas:authenticationSuccess></cas:serviceResponse>`

Our beloved client use a custom version of CAS which nests the `cas:user` node inside a nice `cas:utilisateur` node.

I don't know if it has its place in the main repository, but here is a pull request that cope with this case by looking for the `cas:user` node in the whole tree and not just in the children of `cas:authenticationSuccess`.

Best regards !