### PR TITLE
Update URL suffix for CAS v3 serviceValidate

### DIFF
--- a/cas.py
+++ b/cas.py
@@ -206,7 +206,7 @@ class CASClientV2(CASClientBase):
 
 class CASClientV3(CASClientV2, SingleLogoutMixin):
     """CAS Client Version 3"""
-    url_suffix = 'serviceValidate'
+    url_suffix = 'p3/serviceValidate'
     logout_redirect_param_name = 'service'
 
     @classmethod


### PR DESCRIPTION
Per specification, CAS v3 should use a different URI, which can return
authentication or user attributes:
https://apereo.github.io/cas/5.0.x/protocol/CAS-Protocol-Specification.html#2-cas-uris