### PR TITLE
Add kwarg to bypass SSL certificate validation

### DIFF
--- a/cas.py
+++ b/cas.py
@@ -60,13 +60,14 @@ class CASClientBase(object):
 
     def __init__(self, service_url=None, server_url=None,
                  extra_login_params=None, renew=False,
-                 username_attribute=None):
+                 username_attribute=None, verify_ssl_certificate=True):
 
         self.service_url = service_url
         self.server_url = server_url
         self.extra_login_params = extra_login_params or {}
         self.renew = renew
         self.username_attribute = username_attribute
+        self.verify_ssl_certificate = verify_ssl_certificate
         pass
 
     def verify_ticket(self, ticket):
@@ -131,7 +132,11 @@ class CASClientV1(CASClientBase):
         params = [('ticket', ticket), ('service', self.service_url)]
         url = (urllib_parse.urljoin(self.server_url, 'validate') + '?' +
                urllib_parse.urlencode(params))
-        page = requests.get(url, stream=True)
+        page = requests.get(
+            url,
+            stream=True,
+            verify=self.verify_ssl_certificate
+        )
         try:
             page_iterator = page.iter_lines(chunk_size=8192)
             verified = next(page_iterator).strip()
@@ -167,7 +172,11 @@ class CASClientV2(CASClientBase):
         if self.proxy_callback:
             params.update({'pgtUrl': self.proxy_callback})
         base_url = urllib_parse.urljoin(self.server_url, self.url_suffix)
-        page = requests.get(base_url, params=params)
+        page = requests.get(
+            base_url,
+            params=params,
+            verify=self.verify_ssl_certificate
+        )
         try:
             return page.content
         finally:


### PR DESCRIPTION
As per #15.

1. I didn't add any tests because I'm unsure of how I should write a test for it. It is pretty straight forward though.
2. I didn't add anything for CASv3 because I don't understand the protocol well enough to know where the check is happening. Is it happening in `requests.post()` on `fetch_saml_validation`? Should it be added there?
3. If/when this is merged upstream, I will submit a PR to have support integrated into `django-cas-ng` as a setting.

This is my first contribution to this repo, let me know if I'm missing something.