### PR TITLE
Distribute package as a universal wheel

### DIFF
--- a/docs/release-howto.rst
+++ b/docs/release-howto.rst
@@ -16,6 +16,6 @@ How To Make A Release
 
 6. Upload release to pypi.python.org
 
-    python setup.py sdist upload    
+    python setup.py sdist bdist_wheel upload
 
 7. Create a new release on https://github.com/python-cas/python-cas/releases

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
Wheels are the modern standard of Python distribution

Advantages of wheels:

- Faster installation
- Avoids arbitrary code execution for installation by avoiding setup.py
- Allows better caching for testing and continuous integration
- Creates .pyc files as part of installation to ensure they match the Python interpreter used
- More consistent installs across platforms

When you'd normally run `python3 setup.py sdist upload`, run instead `python3 setup.py sdist bdist_wheel upload`.

For more details, see:

https://pythonwheels.com/