### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,4 +42,3 @@ here. For additional detail, read the complete `commit history`_.
 **python-cas 1.4.0** ``[2018-10-09]``
 
 * Add kwarg `verify_ssl_certificate` to bypass SSL certificate validation
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,4 +20,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/pypi.rst
+++ b/docs/pypi.rst
@@ -1,4 +1,3 @@
-
 Install from source::
 
     python setup install

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,3 @@ setup(
     download_url ='https://github.com/python-cas/python-cas/releases',
     version='1.4.0',
 )
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.