### PR TITLE
Enable native pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
-env:
-  global:
-    - PIP_DOWNLOAD_CACHE=$HOME/.pip_cache
+cache: pip
 
 matrix:
   include:
@@ -19,9 +17,6 @@ matrix:
       sudo: required
     - env: TOX_ENV=flake8
 
-cache:
-  directories:
-    - $HOME/.pip-cache/
 install:
   - "travis_retry pip install setuptools --upgrade"
   - "pip install tox"


### PR DESCRIPTION
Use the native Travis support. For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache