### PR TITLE
Fix setup.py to declare cas.py as a module, not a package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='MIT',
     long_description=readme,
     name='python-cas',
-    packages=['.'],
+    py_modules=['cas'],
     url='https://github.com/python-cas/python-cas',
     download_url ='https://github.com/python-cas/python-cas/releases',
     version='1.4.0',


### PR DESCRIPTION
python-cas is a single module. It should be declared as such in `setup.py`. It is not a multi-file package.

For details, see:

https://docs.python.org/3/distutils/setupscript.html#listing-individual-modules