### PR TITLE
Simplify tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,5 @@ deps =
 commands=py.test --tb native {posargs:tests}
 
 [testenv:flake8]
-basepython=python
 deps=flake8
 commands=flake8 {toxinidir}/cas.py


### PR DESCRIPTION
Remove unnecessary `basepython=python`; it respecifies the default.