### PR TITLE
Remove pytest-pythonpath dependency

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,2 @@
 [pytest]
-python_paths= .
 addopts= --tb native

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 lxml>=3.4
-pytest-pythonpath==0.3
 pytest
 six
 tox==1.8.1


### PR DESCRIPTION
Simplifies testing environment. It is unnecessary.