### PR TITLE
Introduce isort for automatic import ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       dist: xenial
       sudo: required
     - env: TOXENV=flake8
+    - env: TOXENV=isort
 
 install:
   - "travis_retry pip install setuptools --upgrade"

--- a/cas.py
+++ b/cas.py
@@ -1,9 +1,10 @@
-import logging
-import requests
-from six.moves.urllib import parse as urllib_parse
-from uuid import uuid4
 import datetime
+import logging
+from uuid import uuid4
+
+import requests
 from lxml import etree
+from six.moves.urllib import parse as urllib_parse
 
 logger = logging.getLogger(__name__)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,9 @@
 # serve to show the default.
 
 from __future__ import absolute_import
-import sys
+
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,12 @@ universal = 1
 
 [metadata]
 license_file = LICENSE.txt
+
+[isort]
+combine_as_imports = true
+force_grid_wrap = 0
+include_trailing_comma = true
+line_length = 88
+multi_line_output = 3
+not_skip = __init__.py
+skip = .tox

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import codecs
+
 from setuptools import setup
 
 with codecs.open('README.rst', encoding='utf-8') as f:

--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -1,8 +1,11 @@
 """Tests for the cas protocol-related code"""
 from __future__ import absolute_import
+
+import sys
+
 import cas
 from pytest import fixture
-import sys
+
 
 #general tests, apply to all protocols
 #

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     py{27,34,35,36,37}
     flake8
+    isort
 
 [flake8]
 max-line-length= 100
@@ -19,4 +20,9 @@ commands=py.test --tb native {posargs:tests}
 [testenv:flake8]
 deps=flake8
 commands=flake8 {toxinidir}/cas.py
+skip_install = true
+
+[testenv:isort]
+deps = isort
+commands = isort --check-only --diff
 skip_install = true


### PR DESCRIPTION
Removes the need to think about import ordering or formatting. Just let
the tool do it.

https://github.com/timothycrosley/isort

> isort your python imports for you so you don't have to.