### PR TITLE
Simplify dependency handling in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,8 @@ envlist=
 max-line-length= 100
 exclude= tests/*
 
-[base]
-deps =
-    -r{toxinidir}/requirements-dev.txt
-
 [testenv]
-deps =
-    {[base]deps}
+deps = pytest
 commands=py.test --tb native {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
When tox runs, it installs the project _and_ its dependencies. There is
no need to respecify the dependencies listed in setup.py in tox.ini.
This ensures that the dependencies listed in setup.py are correct and
tests pass when they are used.