### PR TITLE
Fix SAML ticket verification failing when response is not namespaced

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ Credits
 * `Édouard Lopez`_.
 * `Guillaume Vincent`_.
 * `Evgeny Fadeev`_.
+* `Mehdi Benadda`_.
 
 References
 ----------
@@ -125,6 +126,6 @@ References
 .. _Édouard Lopez: https://github.com/edouard-lopez
 .. _Guillaume Vincent: https://github.com/guillaumevincent
 .. _Evgeny Fadeev: https://github.com/evgenyfadeev
+.. _Mehdi Benadda: https://github.com/mbenadda
 .. _API Documentation: https://djangocas.dev/docs/latest/modules/python_cas.html
 .. _Sample integration with Flask: https://djangocas.dev/blog/python-cas-flask-example/
-

--- a/cas.py
+++ b/cas.py
@@ -338,7 +338,7 @@ class CASClientWithSAMLV1(CASClientV2, SingleLogoutMixin):
             tree = ElementTree.fromstring(response)
             # Find the authentication status
             success = tree.find('.//' + SAML_1_0_PROTOCOL_NS + 'StatusCode')
-            if success is not None and success.attrib['Value'].endswith(':Success'):
+            if success is not None and success.attrib['Value'].endswith('Success'):
                 # User is validated
                 name_identifier = tree.find('.//' + SAML_1_0_ASSERTION_NS + 'NameIdentifier')
                 if name_identifier is not None:


### PR DESCRIPTION
Hi,

I've encountered a problem where responses would be treated as though login had failed when they contained a `Success` status code.

I was able to track it down to ticket verification picking up status codes ending with `':Success'`. This works fine when the response is namespaced (eg the code is `ns2:Success`) but not otherwise (the code is `Success`).

As far as I know, namespacing of the soap response is not necessary. If the response is not namespaced, the `":"` in the string matcher will cause the client to fail authentication when
it had succeeded.

I think we can safely remove the `:` in the expected status code end substring to support non namespaced responses.