### PR TITLE
Use Session for making requests & allow customization

### DIFF
--- a/tests/test_cas.py
+++ b/tests/test_cas.py
@@ -189,6 +189,28 @@ def test_can_saml_assertion_is_encoded():
     else:
         assert ticket in saml
 
+# Test session= constructor argument with a mock session
+@pytest.mark.skipif(sys.version_info < (3, 3), reason="Mock class not available")
+def test_v3_custom_session():
+    from unittest.mock import Mock
+
+    response = Mock()
+    response.content = SUCCESS_RESPONSE
+    session = Mock()
+    session.get = Mock(return_value=response)
+
+    client = cas.CASClient(
+        version='3',
+        server_url='https://cas.example.com/cas/',
+        service_url='https://example.com/login',
+        session=session)
+    user, attributes, pgtiou = client.verify_ticket('ABC123')
+
+    assert user == 'user@example.com'
+    assert not attributes
+    assert not pgtiou
+
+
 
 @fixture
 def client_v2():


### PR DESCRIPTION
All requests made by python-cas now use a Session object, which enables keep-alive HTTP connections.

The session can also be customized by passing a `session=` argument to `CASClient` constructors, to change behaviors such as HTTP headers, proxies, hooks and more.

My use case requires making all CAS requests through an HTTP proxy.
